### PR TITLE
Allow inverting authzgroup matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tests/_output/
 /tests/*/*Tester.php
 /tests/_support/_generated
+/nbproject

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The library can be installed using composer.
 The library exposes one function with which you can get a list of privileges for matching authz groups.
 Authz groups can be anything you want, in the example below resource URIs are used, but you could also use a string of any format.
 In the example we have a user that has certain permissions attached to him. We can then ask the `PermissionMatcher` class to extract the permissions of the users for a given authz group.
-Note that you can use wildcards `*`.
+Note that you can use wildcards `*`. You can also invert a permission by placing a `!` in front of the authz group.
 
 ```php
 $matcher = new PermissionMatcher();
@@ -45,5 +45,5 @@ echo $matcher->match($permissionsThatSomeUserHas, ['/organizations/0002?list=all
 // outputs ['list']
 
 echo $matcher->match($permissionsThatSomeUserHas, ['/organizations/*']);
-// outputs ['full-access', 'read', 'write', 'list']
+// outputs ['full-access', 'read', 'write']
 ```

--- a/src/PermissionMatcher.php
+++ b/src/PermissionMatcher.php
@@ -24,7 +24,6 @@ class PermissionMatcher
             }
         }
 
-        // exit();
         return $this->flatten($privileges);
     }
 
@@ -85,10 +84,13 @@ class PermissionMatcher
      */
     protected function matchAuthzGroupPaths($pattern, $subject)
     {
-        $regex = '^' . str_replace('[^/]+', '\\*', preg_quote($pattern, '~')) . '$'; // @todo: str_replace does not replace anything here?
+        $regex = '^' . str_replace('[^/]+', '\\*', preg_quote($pattern, '~')) . '$';
         $regex = str_replace('\\*', '(.*)', $regex);
 
-        return preg_match('~' . $regex . '~i', $subject);
+        $invert = $this->stringStartsWith($pattern, '!');
+        $match = preg_match('~' . $regex . '~i', $subject);
+
+        return $invert ? !$match : $match;
     }
 
 
@@ -142,5 +144,17 @@ class PermissionMatcher
         }
 
         return array_unique($list);
+    }
+    
+    /**
+     * Check if a string starts with given substring
+     *
+     * @param string $haystack
+     * @param string $needle
+     * @return boolean
+     */
+    protected function stringStartsWith($haystack, $needle)
+    {
+        return strpos($haystack, $needle) === 0 ? true : false;
     }
 }

--- a/tests/unit/PermissionMatcherTest.php
+++ b/tests/unit/PermissionMatcherTest.php
@@ -184,4 +184,16 @@ class PermissionMatcherTest extends \Codeception\TestCase\Test
         $this->assertArrayMatches(['write'], $this->matcher->match($permissions, ['/admin?RolE=support']));
         $this->assertArrayMatches(['party'], $this->matcher->match($permissions, ['/admin?joB=lawyer&FroM=amsterdam']));
     }
+    
+    public function testMatchInverted()
+    {
+        $permissions = [
+            '!admin' => 'read',
+            'admin' => ['read', 'write']
+        ];
+
+        $this->assertArrayMatches(['read', 'write'], $this->matcher->match($permissions, ['admin']));
+        $this->assertArrayMatches(['read'], $this->matcher->match($permissions, ['guest']));
+        $this->assertArrayMatches(['read'], $this->matcher->match($permissions, ['foo']));
+    }
 }


### PR DESCRIPTION
 You can invert the result of a match by placing a `!` in front of a authz group, see added test.